### PR TITLE
r81: Re-read loop device's partition table before pv

### DIFF
--- a/scripts/chromeos-install.sh
+++ b/scripts/chromeos-install.sh
@@ -243,6 +243,8 @@ if [[ $device = 1 ]]; then
 	fi
 	loopdevice=$(losetup --show -fP "$source")
 	sleep 5
+	partx -u "$loopdevice"
+	sleep 5
 	for (( i=1; i<=12; i++ )); do
 		echo "Writing partition $i"
 		case $i in


### PR DESCRIPTION
Currently the scripts/chromeos-install.sh install script doesn't re-read
loop device's partition table before copying the partitions to the usb
drive. This causes pv not to find the partitions if the loop device was
used with different image before.

To fix that, partx the loop device before pv-ing its partitions to
the target device.

Fixes #97