### PR TITLE
[In-Progress] Add Nvidia Driver 

### DIFF
--- a/patches/99-nouveau_patch.sh
+++ b/patches/99-nouveau_patch.sh
@@ -8,7 +8,7 @@ ret=0
 if [ "$nouveau" -eq 1 ]; then
         echo "brunch: $0 nouveau enabled" > /dev/kmsg
         cat >/system/etc/init/nouveau.conf <<MODPROBE
-start on stopped udev-trigger
+start on startup
  
 script
         modprobe nouveau

--- a/patches/99-nouveau_patch.sh
+++ b/patches/99-nouveau_patch.sh
@@ -1,0 +1,19 @@
+nouveau=0
+for i in $(echo "$1" | sed 's#,# #g')
+do
+        if [ "$i" == "nouveau" ]; then nouveau=1; fi
+done
+ 
+ret=0
+if [ "$nouveau" -eq 1 ]; then
+        echo "brunch: $0 nouveau enabled" > /dev/kmsg
+        cat >/system/etc/init/nouveau.conf <<MODPROBE
+start on stopped udev-trigger
+ 
+script
+        modprobe nouveau
+end script
+MODPROBE
+        if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 0))); fi
+fi
+exit $ret


### PR DESCRIPTION
I was able to get this nouveau patch to load the drivers on boot. It's a simple clone of another patch, modified to work with this. This is non-functional, however, ChromeOS starts to boot. This is progress from previous attempts where the system would freeze before reaching the boot stage. I can't find the error, but I'm hoping that this can be used to give basic driver support for Nvidia.

I believe that disabling the i915 (intel UHD) driver is not needed. When enabling my Nvidia GTX 1060, the system could not get past the boot splash.

To-do:

- [x] Have Module Load on Boot
- [x] Get Past Boot Splash
- [ ] Get to Login Screen
- [ ] Working with Crostini
- [ ] Working with Android