### PR TITLE
Hide UEFI: Secure Boot Enabled verbose

### DIFF
--- a/efi-mods/efi/boot/grub.cfg
+++ b/efi-mods/efi/boot/grub.cfg
@@ -3,7 +3,7 @@ set timeout=2
 menuentry "ChromeOS" {
 	regexp --set disk "(^.+)(,gpt)" $root
 	linux ($disk,7)/kernel boot=local noresume noswap loglevel=7 disablevmx=off cros_secure cros_debug \
-  		console= vt.global_cursor_default=0 brunch_bootsplash=default
+  		console= vt.global_cursor_default=0 brunch_bootsplash=default quiet
 	initrd ($disk,7)/lib/firmware/amd-ucode.img ($disk,7)/lib/firmware/intel-ucode.img ($disk,7)/initramfs.img
 }
 


### PR DESCRIPTION
For a fully textless boot, add the `quiet` flag to grub.cfg. Doesn't do anything to systems w/o secure boot, but with systems on secure boot, a little verbose may be printed without it. Quiet seems to hide it.