### PR TITLE
Remove outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Hardware support is highly dependent on the general Linux kernel hardware compat
 
 
 ❌ Unsupported Hardware:
-- Nvidia GPUs are not supported
+- dGPUs are not supported
 - Virtual Machines are not supported
 - ARM CPUs are not supported
 - Intel Core 2 Duo *and older* are not supported

--- a/install-with-linux.md
+++ b/install-with-linux.md
@@ -41,7 +41,7 @@ This guide is for installing Brunch to a USB (or other disk) using Linux. This g
 * ["zork" is suggested for Ryzen.][recovery-zork]
   * [Ryzen 4xxx devices need kernel 5.10][changing-kernels]
 
-Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] or the [cros-updates-serving][cros-official] site and searching for the recovery you want.
+Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] and searching for the recovery you want.
 
 After selecting the recovery you want, you can select a specific release. Posted releases may be behind the current release, this is normal and you can update into the current release later. It is usually suggested to use the latest release avaliable.
 
@@ -217,7 +217,7 @@ This guide is for installing Brunch to a partition using Linux. This guide is *n
 * ["zork" is suggested for Ryzen.][recovery-zork]
   * [Ryzen 4xxx devices need kernel 5.10][changing-kernels]
 
-Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] or the [cros-updates-serving][cros-official] site and searching for the recovery you want.
+Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] and searching for the recovery you want.
 
 After selecting the recovery you want, you can select a specific release. Posted releases may be behind the current release, this is normal and you can update into the current release later. It is usually suggested to use the latest release avaliable.
 

--- a/install-with-windows.md
+++ b/install-with-windows.md
@@ -43,7 +43,7 @@ This guide is for installing Brunch to a USB (or other disk) using Windows. This
 * ["zork" is suggested for Ryzen.][recovery-zork]
   * [Ryzen 4xxx devices need kernel 5.10][changing-kernels]
 
-Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] or the [cros-updates-serving][cros-official] site and searching for the recovery you want.
+Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] and searching for the recovery you want.
 
 After selecting the recovery you want, you can select a specific release. Posted releases may be behind the current release, this is normal and you can update into the current release later. It is usually suggested to use the latest release avaliable.
 
@@ -214,7 +214,7 @@ This guide is for installing Brunch to a partition using Windows WSL2.
 * ["zork" is suggested for Ryzen.][recovery-zork]
   * [Ryzen 4xxx devices need kernel 5.10][changing-kernels]
 
-Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] or the [cros-updates-serving][cros-official] site and searching for the recovery you want.
+Recoveries can be found by clicking the above links. They can also be found by going to [cros.tech][cros-tech] and searching for the recovery you want.
 
 After selecting the recovery you want, you can select a specific release. Posted releases may be behind the current release, this is normal and you can update into the current release later. It is usually suggested to use the latest release avaliable.
 

--- a/troubleshooting-and-faqs.md
+++ b/troubleshooting-and-faqs.md
@@ -324,9 +324,30 @@ It is currently recommended to only update ChromeOS when the matching version of
 ```sudo chromeos-update -r ~/Downloads/recovery.bin -f ~/Downloads/brunch_archive.tar.gz```
  * Restart ChromeOS after the update finishes.
   
-  Brunch and ChromeOS can also be updated with the [BiteDasher's Script][bite-dasher]
+  Brunch and ChromeOS can also be updated with [BiteDasher's Script][bite-dasher]
   
   </details>
+  
+  
+ ## How to update ChromeOS
+  
+<details>
+<summary> Click to learn how to update ChromeOS </summary>
+  
+  ***
+ 
+ The easiest way to update ChromeOS is to enable the `enable_updates` framework option, then update directly from the Settings page.
+ 
+ To enable the framework option: 
+ * Open the Crosh Shell with **Crtl + Alt + T** and enter `shell` at the prompt.
+ * Enter `sudo edit-brunch-config` to open the Brunch Configuration Menu described above.
+ * Select `enable_updates` with the spacebar, then continue through the menu with the enter key.
+ * When finished, the Brunch Configuration Menu will prompt to restart ChromeOS.
+ * Update from the standard ChromeOS settings page after rebooting.
+  
+  </details>
+  
+  
   
  ## How to update Brunch
   
@@ -345,8 +366,6 @@ It is currently recommended to only update ChromeOS when the matching version of
 
 ```sudo chromeos-update -f ~/Downloads/brunch_archive.tar.gz```
  * Restart ChromeOS after the update finishes.
-  
-  Brunch can also be updated with the [Brunch Toolkit][brunch-toolkit]
   
   </details>
 


### PR DESCRIPTION
Removes outdated links to recoveries
Removes link to Brunch Toolkit
Adjusts phrasing about unsupported GPUs to be more general
Add "How to Update ChromeOS" to troubleshooting page