### PR TITLE
Note about removing TPM grub module

### DIFF
--- a/install-with-linux.md
+++ b/install-with-linux.md
@@ -295,11 +295,18 @@ The installation will report that ChromeOS was installed when it is finished. Be
 
 ```sudo nano /etc/grub.d/99_brunch```
   
-15. Paste the Grub Boot Entries that you copied at the *end* of this file. These boot entries must be *after* the code that is already in this file, *do not remove the existing lines of code*.
+15. Paste the Grub Boot Entries that you copied at the *end* of this file. These boot entries must be *after* the code that is already in this file, *do not remove the existing lines of code*. 
+  * NOTE: On devices with hardware TPM module it may be necessary to remove the 'tpm' grub module, otherwise the loopback mounting fails (a known grub2 bug - see [grub2-bug-1851311]). Insert the line ```rmmod tpm``` before every  ```loopback loop ...``` instance in the ```/etc/grub.d/99_brunch``` file.  E.g.:
+<pre>
+menuentry "Brunch" --class "brunch" {
+        <b>rmmod tpm</b>
+        img_path=/chromeos.img
+        img_uuid=9113c3b2-...
+</pre>
 
-16. Save and close this file. In `nano` you'll exit by pressing **Ctrl + X** then **Y** to save. Then press **Enter** to confirm.
+17. Save and close this file. In `nano` you'll exit by pressing **Ctrl + X** then **Y** to save. Then press **Enter** to confirm.
 
-17. After saving, commit the new entries to Grub.
+18. After saving, commit the new entries to Grub.
 
 ```sudo update-grub```
   
@@ -382,6 +389,7 @@ In case you run into issues while installing or using Brunch, you can find suppo
 [rufus-link]: https://rufus.ie/
 [etcher-link]: https://www.balena.io/etcher/
 [grub2win]: https://sourceforge.net/projects/grub2win/
+[grub2-bug-1851311]: https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/1851311/comments/51
 
 <!-- Images -->
 [decon-icon-24]: ./images/decon_icon-24.png

--- a/install-with-linux.md
+++ b/install-with-linux.md
@@ -302,6 +302,9 @@ menuentry "Brunch" --class "brunch" {
         <b>rmmod tpm</b>
         img_path=/chromeos.img
         img_uuid=9113c3b2-...
+        search --no-floppy --set=root --file $img_path
+        <b><i>loopback loop $img_path</i></b>
+        ...
 </pre>
 
 17. Save and close this file. In `nano` you'll exit by pressing **Ctrl + X** then **Y** to save. Then press **Enter** to confirm.


### PR DESCRIPTION
While installing BRUNCH in a partition (instead of whole disk) recently, I discovered that the presence of a TPM module in the machine can lead to a failure in the loopback mounting due to a well-known bug in grub2
https://askubuntu.com/a/1244886/497474
https://askubuntu.com/questions/1186040/grub-command-loopback-loop-does-not-work-on-ubuntu-19-10

The proposed PR adds a note about that fact, and a work-around it for BRUNCH

I have only tested this on a Debian 12 Linux install. If testing on other Linux flavors is needed/requested, I can try Rocky9 (a popular RH9/CentOS9 derivative). No Windows testing on my side though - I have no such computers. 