### PR TITLE
Fixed camera discovery

### DIFF
--- a/brunch-patches/50-add_generic_firmwares.sh
+++ b/brunch-patches/50-add_generic_firmwares.sh
@@ -31,11 +31,13 @@ if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 2))); fi
 
 if [ "$no_camera_config" -eq 1 ]; then
 cat >/roota/etc/init/camera.conf <<CAMERASCRIPT
-start on starting boot-services
+start on stopped udev-trigger
 
 script
 if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_characteristics.conf; fi
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
+
+logger -t "camera.conf" "Starting camera discovery"
 
 nr=0
 for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do
@@ -49,11 +51,13 @@ end script
 CAMERASCRIPT
 elif [ "$invert_camera_order" -eq 1 ]; then
 cat >/roota/etc/init/camera.conf <<CAMERASCRIPT
-start on starting boot-services
+start on stopped udev-trigger
 
 script
 if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_characteristics.conf; fi
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
+
+logger -t "camera.conf" "Starting camera discovery"
 
 nr=0
 for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq | tac); do
@@ -84,11 +88,13 @@ end script
 CAMERASCRIPT
 else
 cat >/roota/etc/init/camera.conf <<CAMERASCRIPT
-start on starting boot-services
+start on stopped udev-trigger
 
 script
 if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_characteristics.conf; fi
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
+
+logger -t "camera.conf" "Starting camera discovery"
 
 nr=0
 for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do

--- a/brunch-patches/50-add_generic_firmwares.sh
+++ b/brunch-patches/50-add_generic_firmwares.sh
@@ -38,7 +38,7 @@ if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_ch
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
 
 nr=0
-for i in \$(dmesg | grep "uvcvideo: Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do
+for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do
 vendor=\$(echo \$i | cut -d: -f1)
 product=\$(echo \$i | cut -d: -f2)
 echo "SUBSYSTEM==\"video4linux\", ATTRS{idVendor}==\"\$vendor\", ATTRS{idProduct}==\"\$product\", SYMLINK+=\"camera-internal\$nr\"" >> /lib/udev/rules.d/50-camera.rules
@@ -56,7 +56,7 @@ if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_ch
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
 
 nr=0
-for i in \$(dmesg | grep "uvcvideo: Found UVC" | sed 's/^.*(//;s/)\$//' | uniq | tac); do
+for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq | tac); do
 vendor=\$(echo \$i | cut -d: -f1)
 product=\$(echo \$i | cut -d: -f2)
 echo "SUBSYSTEM==\"video4linux\", ATTRS{idVendor}==\"\$vendor\", ATTRS{idProduct}==\"\$product\", SYMLINK+=\"camera-internal\$nr\"" >> /lib/udev/rules.d/50-camera.rules
@@ -91,7 +91,7 @@ if [ -f /etc/camera/camera_characteristics.conf ]; then rm /etc/camera/camera_ch
 if [ -f /lib/udev/rules.d/50-camera.rules ]; then rm /lib/udev/rules.d/50-camera.rules; fi
 
 nr=0
-for i in \$(dmesg | grep "uvcvideo: Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do
+for i in \$(dmesg | grep "Found UVC" | sed 's/^.*(//;s/)\$//' | uniq); do
 vendor=\$(echo \$i | cut -d: -f1)
 product=\$(echo \$i | cut -d: -f2)
 echo "SUBSYSTEM==\"video4linux\", ATTRS{idVendor}==\"\$vendor\", ATTRS{idProduct}==\"\$product\", SYMLINK+=\"camera-internal\$nr\"" >> /lib/udev/rules.d/50-camera.rules


### PR DESCRIPTION
The script that creates rules for the laptop cameras is dependent on kernel log. But the kernel log format has changed - there is no more prefix "uvcvideo". Typical kernel log in recent kernel is like this:

usb 1-7: Found UVC 1.00 device HD User Facing (04f2:b64f)

Also the moment this script should be executed is after udev-trigger finished. Otherwise it will not find the relevant logs in the dmesg.

That is the reason why /dev/camera-internal* were not created and why many Android apps ignore the camera.

Fixes #2297